### PR TITLE
Fixed extra arrow typo in app component

### DIFF
--- a/apps/web/src/app/app.component.html
+++ b/apps/web/src/app/app.component.html
@@ -1,3 +1,3 @@
 <ion-app>
     <ion-router-outlet></ion-router-outlet>
-</ion-app>>
+</ion-app>


### PR DESCRIPTION
Removed the extra `>` arrow typo in app-component.